### PR TITLE
Refactor backfill

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -8,6 +8,10 @@ task :backfill do
   ruby "backfill.rb"
 end
 
+task :clear_registry do
+  ruby "clear_registry.rb"
+end
+
 task :test_executive_order_registry do
   ruby "executive_order_registry_test.rb"
 end

--- a/Rakefile
+++ b/Rakefile
@@ -4,8 +4,16 @@ task :test do
   ruby "test.rb"
 end
 
-task :backfill do
-  ruby "backfill.rb"
+namespace :backfill do
+  desc "Log the results of the backfill locally"
+  task :log do
+    ruby "backfill.rb log"
+  end
+
+  desc "Backfill the Twitter account"
+  task :twitter do
+    ruby "backfill.rb twitter"
+  end
 end
 
 task :clear_registry do

--- a/backfill.rb
+++ b/backfill.rb
@@ -1,7 +1,7 @@
 require "./federal_register"
 require "./executive_order_processor"
 
-processor = ExecutiveOrderProcessor.new
+processor = ExecutiveOrderProcessor.new(ARGV.first.to_sym)
 
 FederalRegister.backfill.each do |executive_order|
   processor.process(executive_order)

--- a/backfill.rb
+++ b/backfill.rb
@@ -1,9 +1,8 @@
 require "./federal_register"
-require "./twitter_account"
+require "./executive_order_processor"
 
-twitter_account = TwitterAccount.new
-api_results = FederalRegister.backfill["results"]
+processor = ExecutiveOrderProcessor.new
 
-api_results.each do |result|
-  twitter_account.tweet(TwitterAccount.truncate_content(result["title"], result["html_url"]))
+FederalRegister.backfill.each do |executive_order|
+  processor.process(executive_order)
 end

--- a/clear_registry.rb
+++ b/clear_registry.rb
@@ -1,0 +1,3 @@
+require "./executive_order_registry"
+
+ExecutiveOrderRegistry.new.clear

--- a/executive_order_processor.rb
+++ b/executive_order_processor.rb
@@ -9,8 +9,6 @@ class ExecutiveOrderProcessor
   def process(executive_order)
     return if registry.registered?(executive_order)
 
-    registry.register(executive_order)
-
     tweet = TwitterAccount.truncate_content(executive_order.title, executive_order.url)
 
     case @strategy
@@ -19,6 +17,7 @@ class ExecutiveOrderProcessor
       puts "--------"
     when :twitter
       twitter_account.tweet(tweet)
+      registry.register(executive_order)
     end
   end
 

--- a/executive_order_processor.rb
+++ b/executive_order_processor.rb
@@ -1,0 +1,34 @@
+require "./twitter_account"
+require "./executive_order_registry"
+
+class ExecutiveOrderProcessor
+  def initialize(strategy = :log)
+    @strategy = strategy
+  end
+
+  def process(executive_order)
+    return if registry.registered?(executive_order)
+
+    registry.register(executive_order)
+
+    tweet = TwitterAccount.truncate_content(executive_order.title, executive_order.url)
+
+    case @strategy
+    when :log
+      puts tweet
+      puts "--------"
+    when :twitter
+      twitter_account.tweet(tweet)
+    end
+  end
+
+  private
+
+  def registry
+    @registry ||= ExecutiveOrderRegistry.new
+  end
+
+  def twitter_account
+    @twitter_account ||= TwitterAccount.new
+  end
+end

--- a/federal_register.rb
+++ b/federal_register.rb
@@ -1,17 +1,15 @@
 require "faraday"
 require "json"
-require "pp"
+require "./executive_order"
 
 class FederalRegister
   def self.test
-    res = Faraday.get("https://www.federalregister.gov/api/v1/documents.json?per_page=50&order=newest&conditions%5Bpresidential_document_type%5D%5B%5D=executive_order")
-
-    pp JSON.parse(res.body)
+    Faraday.get("https://www.federalregister.gov/api/v1/documents.json?per_page=50&order=newest&conditions%5Bpresidential_document_type%5D%5B%5D=executive_order").body
   end
 
   def self.backfill
-    res = Faraday.get("https://www.federalregister.gov/api/v1/documents.json?per_page=50&order=newest&conditions%5Bpublication_date%5D%5Bgte%5D=2017-01-24&conditions%5Bpresidential_document_type%5D%5B%5D=executive_order")
+    res = Faraday.get("https://www.federalregister.gov/api/v1/documents.json?per_page=50&order=oldest&conditions%5Bpublication_date%5D%5Bgte%5D=2017-01-24&conditions%5Bpresidential_document_type%5D%5B%5D=executive_order")
 
-    pp JSON.parse(res.body)
+    JSON.parse(res.body)["results"].map { |eo| ExecutiveOrder.from_federal_register_hash(eo) }
   end
 end


### PR DESCRIPTION
This branch refactors the backfill task, letting you specify whether you want to tweet the backfill or just log it out to the console. It also uses the new ExecutiveOrder model stuff, and adds an ExecutiveOrderProcessor task to encapsulate the process of tweeting/registering or logging to console.

/cc @jessicard 